### PR TITLE
refactor steps/tools parsing and unify logging info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#267](https://github.com/nf-core/phaseimpute/pull/267) - Refactor repeated `params.steps` / `params.tools` and replace `println` calls with `log.info`.
 - [#244](https://github.com/nf-core/phaseimpute/pull/244) - Start migration to strict syntax.
 - [#237](https://github.com/nf-core/phaseimpute/pull/237) - Bump version to 1.2.0dev and update `CHANGELOG.md`.
 - [#232](https://github.com/nf-core/phaseimpute/pull/232) - Make posfile generated in the panelprep step.

--- a/main.nf
+++ b/main.nf
@@ -56,6 +56,7 @@ workflow NFCORE_PHASEIMPUTE {
     ch_input_impute         = channel.empty()
     ch_input_simulate       = channel.empty()
     ch_input_validate       = channel.empty()
+    def steps               = params.steps.split(',') as List
 
     //  Check input files for contigs names consistency
     lst_chr = ch_regions.map {meta, _region -> meta.chr }
@@ -75,11 +76,11 @@ workflow NFCORE_PHASEIMPUTE {
     )
     ch_panel = CHRCHECK_PANEL.out.output
 
-    if (params.steps.split(',').contains("simulate") || params.steps.split(',').contains("all")) {
+    if (steps.contains("simulate") || steps.contains("all")) {
         ch_input_simulate = ch_input
-    } else if (params.steps.split(',').contains("impute")) {
+    } else if (steps.contains("impute")) {
         ch_input_impute   = ch_input
-    } else if (params.steps.split(',').contains("validate")) {
+    } else if (steps.contains("validate")) {
         ch_input_validate = ch_input
     }
 

--- a/subworkflows/local/utils_nfcore_phaseimpute_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_phaseimpute_pipeline/main.nf
@@ -98,6 +98,9 @@ workflow PIPELINE_INITIALISATION {
     //
     validateInputParameters()
 
+    def steps = params.steps.split(',') as List
+    def tools = params.tools ? params.tools.split(',') as List : []
+
     //
     // Create fasta channel
     //
@@ -157,7 +160,7 @@ workflow PIPELINE_INITIALISATION {
         ch_input,
         params.batch_size,
         getFilesSameExt(ch_input),
-        params.tools ? params.tools.split(',') : []
+        tools
     )
 
     //
@@ -189,7 +192,7 @@ workflow PIPELINE_INITIALISATION {
         // #TODO Add support for string input
         ch_regions  = getRegionFromFai("all", ch_ref_gen)
     }  else  if (params.input_region.endsWith(".csv")) {
-        println "Region file provided as input is a samplesheet"
+        log.info "Region file provided as input is a samplesheet"
         ch_regions = channel.from(samplesheetToList(
             params.input_region, "${projectDir}/assets/schema_input_region.json"
         ))
@@ -207,7 +210,7 @@ workflow PIPELINE_INITIALISATION {
     //
     if (params.panel) {
         if (params.panel.endsWith("csv")) {
-            println "Panel file provided as input is a samplesheet"
+            log.info "Panel file provided as input is a samplesheet"
             ch_panel = channel.fromList(samplesheetToList(
                 params.panel, "${projectDir}/assets/schema_input_panel.json"
             )).map {
@@ -228,7 +231,7 @@ workflow PIPELINE_INITIALISATION {
     //
     if (params.map) {
         if (params.map.endsWith(".csv")) {
-            println "Map file provided as input is a samplesheet"
+            log.info "Map file provided as input is a samplesheet"
             ch_map = channel.fromList(samplesheetToList(params.map, "${projectDir}/assets/schema_map.json"))
         } else {
             error "Map file provided is of another format than CSV (not yet supported). Please separate your reference genome by chromosome and use the samplesheet format."
@@ -270,11 +273,11 @@ workflow PIPELINE_INITIALISATION {
             .map{ metaPC, _vcf, _index -> [metaPC, [], [], [], [], []]}
     }
 
-    if (!params.steps.split(',').contains("panelprep") & !params.steps.split(',').contains("all")) {
+    if (!steps.contains("panelprep") & !steps.contains("all")) {
         validatePosfileTools(
             ch_posfile,
-            params.tools ? params.tools.split(','): [],
-            params.steps.split(','),
+            tools,
+            steps,
             input_truth_ext
         )
     }
@@ -490,47 +493,50 @@ def validateInputParameters() {
     assert params.steps : "A step must be provided"
 
     // Check that at least one tool is provided
-    if (params.steps.split(',').contains("impute")) {
+    def steps = params.steps.split(',') as List
+    def tools = params.tools ? params.tools.split(',') as List : []
+
+    if (steps.contains("impute")) {
         assert params.tools : "No tools provided"
     }
 
     // Check that input is provided for all steps, except panelprep
-    if (params.steps.split(',').contains("all") || params.steps.split(',').contains("impute") || params.steps.split(',').contains("simulate") || params.steps.split(',').contains("validate")) {
+    if (steps.contains("all") || steps.contains("impute") || steps.contains("simulate") || steps.contains("validate")) {
         assert params.input : "No input provided"
     }
 
     // Check that posfile and panel are provided when running impute only
-    if (params.steps.split(',').contains("impute") && !params.steps.split(',').find { step -> step in ["all", "panelprep"] }) {
+    if (steps.contains("impute") && !steps.find { step -> step in ["all", "panelprep"] }) {
         // Required by all tools except glimpse2, beagle5, minimac4
-        if (!params.tools.split(',').find { tool -> tool in ["glimpse2", "beagle5", "minimac4"] }) {
+        if (!tools.find { tool -> tool in ["glimpse2", "beagle5", "minimac4"] }) {
             assert params.posfile : "No --posfile provided for --steps impute"
         }
         // Required by glimpse1 and glimpse2 only
-        if (params.tools.split(',').find { tool -> tool in ["glimpse1", "glimpse2"] }) {
+        if (tools.find { tool -> tool in ["glimpse1", "glimpse2"] }) {
             assert params.panel : "No --panel provided for imputation with GLIMPSE1 or GLIMPSE2"
         }
     }
 
     // Check that input_truth is provided when running validate
-    if (params.steps.split(',').find { step -> step in ["validate"] } && !params.steps.split(',').find { step -> step in ["simulate"] }) {
+    if (steps.find { step -> step in ["validate"] } && !steps.find { step -> step in ["simulate"] }) {
         assert params.input_truth : "No --input_truth was provided for --steps validate"
     }
 
     // Emit a warning if both panel and (chunks || posfile) are used as input
-    if (params.panel && params.chunks && params.steps.split(',').find { step -> step in ["all", "panelprep"]} ) {
+    if (params.panel && params.chunks && steps.find { step -> step in ["all", "panelprep"]} ) {
         log.warn("Both `--chunks` and `--panel` have been provided. Provided `--chunks` will override `--panel` generated chunks in `--steps impute` mode.")
     }
-    if (params.panel && params.posfile && params.steps.split(',').find { step -> step in ["all", "panelprep"]} ) {
+    if (params.panel && params.posfile && steps.find { step -> step in ["all", "panelprep"]} ) {
         log.warn("Both `--posfile` and `--panel` have been provided. Provided `--posfile` will override `--panel` generated posfile in `--steps impute` mode.")
     }
 
     // Emit an info message when using external panel and impute only
-    if (params.panel && params.steps.split(',').find { step -> step in ["impute"] } && !params.steps.split(',').find { step -> step in ["all", "panelprep"] } ) {
+    if (params.panel && steps.find { step -> step in ["impute"] } && !steps.find { step -> step in ["all", "panelprep"] } ) {
         log.info("Provided `--panel` will be used in `--steps impute`. Make sure it has been previously prepared with `--steps panelprep`")
     }
 
     // Emit an error if normalizing step is ignored but samples need to be removed from reference panel
-    if (params.steps.split(',').find { step -> step in ["all", "panelprep"] } && params.remove_samples) {
+    if (steps.find { step -> step in ["all", "panelprep"] } && params.remove_samples) {
         if (!params.normalize) {
             error("To use `--remove_samples` you need to include `--normalize`.")
         }
@@ -822,8 +828,8 @@ def toolCitationText() {
         GLIMPSE2: "GLIMPSE2 (Rubinacci et al. 2023)",
     ]
 
-    def tools_used = params.tools ? params.tools.split(',') : []
-    def steps_used = params.steps ? params.steps.split(',') : []
+    def tools_used = params.tools ? params.tools.split(',') as List : []
+    def steps_used = params.steps ? params.steps.split(',') as List : []
     if (steps_used.contains("all")) {
         steps_used = ["simulate", "panelprep", "impute", "validate"]
     }
@@ -897,11 +903,11 @@ def toolBibliographyText() {
         GLIMPSE2: '<li>Rubinacci, S., Hofmeister, R.J., Sousa da Mota, B., Delaneau, O., 2023. Imputation of low-coverage sequencing data from 150,119 UK Biobank genomes. Nat Genet 55, 1088-1090. doi: <a href="https://doi.org/10.1038/s41588-023-01438-3">10.1038/s41588-023-01438-3</a></li>',
     ]
 
-    def steps_used = params.steps != null ? params.steps.split(',') : []
+    def steps_used = params.steps != null ? params.steps.split(',') as List : []
     if (steps_used.contains("all")) {
         steps_used = ["simulate", "panelprep", "impute", "validate"]
     }
-    def tools_used = params.tools != null && steps_used.contains("impute") ? params.tools.split(',') : []
+    def tools_used = params.tools != null && steps_used.contains("impute") ? params.tools.split(',') as List : []
 
     def reference_text = [
         tools_used.contains("beagle5")  ? tool_biblio.BEAGLE5  : "",

--- a/workflows/phaseimpute/main.nf
+++ b/workflows/phaseimpute/main.nf
@@ -110,11 +110,13 @@ workflow PHASEIMPUTE {
     main:
 
     ch_multiqc_files = channel.empty()
+    def steps = params.steps.split(',') as List
+    def tools = params.tools ? params.tools.split(',') as List : []
 
     //
     // Simulate data if asked
     //
-    if (params.steps.split(',').contains("simulate") || params.steps.split(',').contains("all")) {
+    if (steps.contains("simulate") || steps.contains("all")) {
         // Test if the input are all bam files
         getFilesSameExt(ch_input_sim)
             .map{ ext -> if (ext != "bam" & ext != "cram") {
@@ -192,7 +194,7 @@ workflow PHASEIMPUTE {
     //
     // Prepare panel
     //
-    if (params.steps.split(',').contains("panelprep") || params.steps.split(',').contains("all")) {
+    if (steps.contains("panelprep") || steps.contains("all")) {
         // Normalize indels in panel
         VCF_NORMALIZE_BCFTOOLS(ch_panel, ch_fasta)
         ch_panel_phased = VCF_NORMALIZE_BCFTOOLS.out.vcf_tbi
@@ -268,7 +270,7 @@ workflow PHASEIMPUTE {
     //
     // Impute target files
     //
-    if (params.steps.split(',').contains("impute") || params.steps.split(',').contains("all")) {
+    if (steps.contains("impute") || steps.contains("all")) {
         // Split input files into BAMs and VCFs
         ch_input_type = ch_input_impute
             .branch { _meta, file, _index ->
@@ -311,11 +313,11 @@ workflow PHASEIMPUTE {
             .join(LISTTOFILE.out.txt)
 
         // Use panel from parameters if provided
-        if (params.panel && !params.steps.split(',').find { step -> step in ["all", "panelprep"] }) {
+        if (params.panel && !steps.find { step -> step in ["all", "panelprep"] }) {
             ch_panel_phased = ch_panel
         }
 
-        if (params.tools.split(',').contains("glimpse1")) {
+        if (tools.contains("glimpse1")) {
             log.info("Impute with GLIMPSE1")
 
             // Use chunks from parameters if provided or use previous chunks from panelprep
@@ -370,7 +372,7 @@ workflow PHASEIMPUTE {
 
         }
 
-        if (params.tools.split(',').contains("glimpse2")) {
+        if (tools.contains("glimpse2")) {
             log.info("Impute with GLIMPSE2")
 
             ch_chunks_glimpse2 = chunkPrepareChannel(ch_chunks, ch_region, "glimpse1")
@@ -400,7 +402,7 @@ workflow PHASEIMPUTE {
             ch_input_validate = ch_input_validate.mix(CONCAT_GLIMPSE2.out.vcf_index)
         }
 
-        if (params.tools.split(',').contains("stitch")) {
+        if (tools.contains("stitch")) {
             log.info("Impute with STITCH")
 
             ch_chunks_stitch = chunkPrepareChannel(ch_chunks, ch_region, "quilt")
@@ -441,7 +443,7 @@ workflow PHASEIMPUTE {
 
         }
 
-        if (params.tools.split(',').contains("quilt")) {
+        if (tools.contains("quilt")) {
             log.info("Impute with QUILT")
 
             // Use provided chunks if --chunks or whole chromosome
@@ -491,7 +493,7 @@ workflow PHASEIMPUTE {
             ch_input_validate = ch_input_validate.mix(CONCAT_QUILT.out.vcf_index)
         }
 
-        if (params.tools.split(',').contains("beagle5")) {
+        if (tools.contains("beagle5")) {
             log.info("Impute with BEAGLE5")
             ch_chunks_beagle5 = chunkPrepareChannel(ch_chunks, ch_region, "glimpse1")
                 .map{ meta, _regionin, regionout -> [meta, regionout]}
@@ -513,7 +515,7 @@ workflow PHASEIMPUTE {
             ch_input_validate = ch_input_validate.mix(CONCAT_BEAGLE5.out.vcf_index)
         }
 
-        if (params.tools.split(',').contains("minimac4")) {
+        if (tools.contains("minimac4")) {
             log.info("Impute with MINIMAC4")
 
             ch_chunks_minimac4 = chunkPrepareChannel(ch_chunks, ch_region, "glimpse1")
@@ -578,7 +580,7 @@ workflow PHASEIMPUTE {
         )
     }
 
-    if (params.steps.split(',').contains("validate") || params.steps.split(',').contains("all")) {
+    if (steps.contains("validate") || steps.contains("all")) {
         // Concatenate all sites into a single VCF (for GLIMPSE concordance)
         CONCAT_PANEL(ch_posfile.map{
             meta, site, site_index, _hap, _legend, _posfile -> [


### PR DESCRIPTION
- Parse `params.steps` and `params.tools` once and reuse `steps / tools` lists instead of repeated `split` calls.
- Replace `println `with `log.info` so informational messages go through Nextflow’s logging system and appear in the execution log.