### PR TITLE
improve genotype usage error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#281](https://github.com/nf-core/phaseimpute/pull/281) - Remove unused `CONCAT_TRUTH` and move  unsupported `--genotype` to parameter validation utils.
+- [#281](https://github.com/nf-core/phaseimpute/pull/281) - Remove unused `CONCAT_TRUTH` and move unsupported `--genotype` to parameter validation utils.
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#281](https://github.com/nf-core/phaseimpute/pull/281) - Remove unused `CONCAT_TRUTH` and move  unsupported `--genotype` to parameter validation utils.
+
 ### `Dependencies`
 
 | Dependency | Old version | New version    |

--- a/subworkflows/local/utils_nfcore_phaseimpute_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_phaseimpute_pipeline/main.nf
@@ -489,6 +489,11 @@ def validateInputParameters() {
     // Check that a steps is provided
     assert params.steps : "A step must be provided"
 
+    // Check that genotype simulation is only used with simulate/all steps
+    if (params.genotype && !params.steps.split(',').find { step -> step in ["simulate", "all"] }) {
+        error("`--genotype` is only supported with `--steps simulate` or `--steps all`. Genotype simulation is not yet implemented.")
+    }
+
     // Check that at least one tool is provided
     if (params.steps.split(',').contains("impute")) {
         assert params.tools : "No tools provided"

--- a/workflows/phaseimpute/main.nf
+++ b/workflows/phaseimpute/main.nf
@@ -81,7 +81,6 @@ include { BCFTOOLS_QUERY as BCFTOOLS_QUERY_TRUTH           } from '../../modules
 include { GAWK as GAWK_TRUTH                               } from '../../modules/nf-core/gawk'
 include { VCF_SPLIT_BCFTOOLS as SPLIT_TRUTH                } from '../../subworkflows/local/vcf_split_bcftools'
 include { BCFTOOLS_STATS as BCFTOOLS_STATS_TRUTH           } from '../../modules/nf-core/bcftools/stats'
-include { VCF_CONCATENATE_BCFTOOLS as CONCAT_TRUTH         } from '../../subworkflows/local/vcf_concatenate_bcftools'
 include { VCF_CONCORDANCE_GLIMPSE2                         } from '../../subworkflows/local/vcf_concordance_glimpse2'
 
 
@@ -173,10 +172,6 @@ workflow PHASEIMPUTE {
                 false
             )
             ch_multiqc_files = ch_multiqc_files.mix(FILTER_CHR_DWN.out.output.map{ _meta, file -> file })
-        }
-
-        if (params.genotype) {
-            error "Genotype simulation not yet implemented"
         }
 
         // Create CSV from simulate step


### PR DESCRIPTION
- Remove unused `CONCAT_TRUTH` module import 
- Move --genotype validation to utils* for immediate parameter validation.