### PR TITLE
Fix shapeit5 hash divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#275](https://github.com/nf-core/phaseimpute/pull/275) - Fix nf-test errors with latest-everything.
 - [#281](https://github.com/nf-core/phaseimpute/pull/281) - Fix `diffchr()` function.
 - [#293](https://github.com/nf-core/phaseimpute/pull/293) - Fix nf-core and nextflow linting.
+- [#298](https://github.com/nf-core/phaseimpute/pull/298) - Stabilise variants md5 hash when using vcffixup.
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#275](https://github.com/nf-core/phaseimpute/pull/275) - Fix nf-test errors with latest-everything.
 - [#281](https://github.com/nf-core/phaseimpute/pull/281) - Fix `diffchr()` function.
 - [#293](https://github.com/nf-core/phaseimpute/pull/293) - Fix nf-core and nextflow linting.
-- [#298](https://github.com/nf-core/phaseimpute/pull/298) - Stabilise variants md5 hash when using vcffixup.
 - [#297](https://github.com/nf-core/phaseimpute/pull/297) - Fix `VCF_NORMALIZE_BCFTOOLS:BCFTOOLS_VIEW` configuration for `remove_samples` to be properly parsed.
+- [#298](https://github.com/nf-core/phaseimpute/pull/298) - Stabilise variants md5 hash when using `VCFLIB_VCFFIXUP` by using `.bcf.gz` files and `.csi` index.
 
 ### `Dependencies`
 

--- a/conf/steps/panelprep.config
+++ b/conf/steps/panelprep.config
@@ -22,14 +22,15 @@ process {
     }
 
     withName: 'NFCORE_PHASEIMPUTE:PHASEIMPUTE:VCF_NORMALIZE_BCFTOOLS:BCFTOOLS_NORM' {
-        ext.args   = ["-m +any", "--output-type z", "--write-index=csi"].join(' ')
+        ext.args   = ["-m +any", "--output-type b", "--write-index=csi"].join(' ')
         ext.prefix = { "${meta.panel_id}_${meta.chr}_multiallelic" }
     }
 
     withName: 'NFCORE_PHASEIMPUTE:PHASEIMPUTE:VCF_NORMALIZE_BCFTOOLS:BCFTOOLS_VIEW' {
         ext.args = {
             def rm_samples = params.remove_samples ? "-s^${params.remove_samples}  --force-samples" : ""
-            return "-v snps -m 2 -M 2 --output-type z --write-index=csi ${rm_samples}"
+            def output_format = params.compute_freq ? "--output-type z" : "--output-type b"
+            return "-v snps -m 2 -M 2 --write-index=csi ${rm_samples} ${output_format}"
         }
         ext.prefix = { "${meta.panel_id}_${meta.chr}_normalized" }
         publishDir = [

--- a/conf/steps/panelprep.config
+++ b/conf/steps/panelprep.config
@@ -22,16 +22,15 @@ process {
     }
 
     withName: 'NFCORE_PHASEIMPUTE:PHASEIMPUTE:VCF_NORMALIZE_BCFTOOLS:BCFTOOLS_NORM' {
-        ext.args   = ["-m +any", "--output-type z", "--write-index=tbi"].join(' ')
+        ext.args   = ["-m +any", "--output-type z", "--write-index=csi"].join(' ')
         ext.prefix = { "${meta.panel_id}_${meta.chr}_multiallelic" }
     }
 
     withName: 'NFCORE_PHASEIMPUTE:PHASEIMPUTE:VCF_NORMALIZE_BCFTOOLS:BCFTOOLS_VIEW' {
-        ext.args   = [
-            "-v snps", "-m 2", "-M 2",
-            params.remove_samples ? "-s^${params.remove_samples}" : '',
-            "--output-type z", "--write-index=tbi"
-        ].join(' ')
+        ext.args = {
+            def rm_samples = params.remove_samples ? "-s^${params.remove_samples}" : ""
+            return "-v snps -m 2 -M 2 --output-type b --write-index=csi ${rm_samples}"
+        }
         ext.prefix = { "${meta.panel_id}_${meta.chr}_normalized" }
         publishDir = [
             path: { "${params.outdir}/prep_panel/panel" },
@@ -62,7 +61,7 @@ process {
     }
 
     withName: 'NFCORE_PHASEIMPUTE:PHASEIMPUTE:VCF_NORMALIZE_BCFTOOLS:BCFTOOLS_INDEX' {
-        ext.args   = "--tbi"
+        ext.args   = "--csi"
         publishDir = [
             path: { "${params.outdir}/prep_panel/panel" },
             mode: params.publish_dir_mode,

--- a/conf/steps/panelprep.config
+++ b/conf/steps/panelprep.config
@@ -62,21 +62,6 @@ process {
         ]
     }
 
-    withName: 'NFCORE_PHASEIMPUTE:PHASEIMPUTE:VCF_NORMALIZE_BCFTOOLS:BCFTOOLS_INDEX' {
-        ext.args   = "--csi"
-        publishDir = [
-            path: { "${params.outdir}/prep_panel/panel" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename ->
-                if ( !params.phase || params.publish_all ) {
-                    filename
-                } else {
-                    null
-                }
-            }
-        ]
-    }
-
     // Subworkflow: VCF_PHASE_SHAPEIT5
     withName: 'NFCORE_PHASEIMPUTE:PHASEIMPUTE:VCF_PHASE_SHAPEIT5:.*' {
         publishDir = [

--- a/conf/steps/panelprep.config
+++ b/conf/steps/panelprep.config
@@ -29,7 +29,7 @@ process {
     withName: 'NFCORE_PHASEIMPUTE:PHASEIMPUTE:VCF_NORMALIZE_BCFTOOLS:BCFTOOLS_VIEW' {
         ext.args = {
             def rm_samples = params.remove_samples ? "-s^${params.remove_samples}  --force-samples" : ""
-            return "-v snps -m 2 -M 2 --output-type z --write-index=tbi ${rm_samples}"
+            return "-v snps -m 2 -M 2 --output-type z --write-index=csi ${rm_samples}"
         }
         ext.prefix = { "${meta.panel_id}_${meta.chr}_normalized" }
         publishDir = [
@@ -47,6 +47,7 @@ process {
 
     withName: 'NFCORE_PHASEIMPUTE:PHASEIMPUTE:VCF_NORMALIZE_BCFTOOLS:VCFLIB_VCFFIXUP' {
         ext.prefix = { "${meta.panel_id}_${meta.chr}_fixup" }
+        ext.args2 = "--output-type b --write-index=csi"
         publishDir = [
             path: { "${params.outdir}/prep_panel/panel" },
             mode: params.publish_dir_mode,

--- a/conf/test_panelprep.config
+++ b/conf/test_panelprep.config
@@ -36,7 +36,7 @@ params {
     // Panelprep optional args
     remove_samples = "HG00096,HG00097,HG00099,HG00100"
     normalize      = true
-    compute_freq   = false
+    compute_freq   = true
     phase          = true
     chunk_model    = "recursive"
 }

--- a/conf/test_panelprep.config
+++ b/conf/test_panelprep.config
@@ -36,7 +36,7 @@ params {
     // Panelprep optional args
     remove_samples = "HG00096,HG00097,HG00099,HG00100"
     normalize      = true
-    compute_freq   = true
+    compute_freq   = false
     phase          = true
     chunk_model    = "recursive"
 }

--- a/modules.json
+++ b/modules.json
@@ -228,7 +228,7 @@
                     },
                     "vcflib/vcffixup": {
                         "branch": "master",
-                        "git_sha": "9268f2ac9d9c520ffcc8eeb1078b4ccc461697b1",
+                        "git_sha": "ecd5df5f44d895a81bda2b47bc5b760596bce72f",
                         "installed_by": ["modules"]
                     }
                 }

--- a/modules.json
+++ b/modules.json
@@ -203,12 +203,12 @@
                     },
                     "shapeit5/ligate": {
                         "branch": "master",
-                        "git_sha": "25ac0da595fac900aba3041d2bcdd7eb338192d0",
+                        "git_sha": "8556a739676498417d5b323107e8db43089cf303",
                         "installed_by": ["modules", "vcf_phase_shapeit5"]
                     },
                     "shapeit5/phasecommon": {
                         "branch": "master",
-                        "git_sha": "236d7f19efcffccdfac5e1850af2aa035e0de79c",
+                        "git_sha": "8556a739676498417d5b323107e8db43089cf303",
                         "installed_by": ["modules", "vcf_phase_shapeit5"]
                     },
                     "stitch": {

--- a/modules/nf-core/shapeit5/ligate/main.nf
+++ b/modules/nf-core/shapeit5/ligate/main.nf
@@ -3,9 +3,9 @@ process SHAPEIT5_LIGATE {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/shapeit5:5.1.1--hb60d31d_0'
-        : 'biocontainers/shapeit5:5.1.1--hb60d31d_0'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fa/fa06870e893f9045944461e5b674adffec6deec41e8496b63ec54d44a98d6134/data'
+        : 'community.wave.seqera.io/library/shapeit5:5.1.1--09a6cb254ece8f6e'}"
 
     input:
     tuple val(meta), path(input_list), path(input_list_index)
@@ -44,7 +44,7 @@ process SHAPEIT5_LIGATE {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def suffix = suffix_ ?: "vcf.gz"
     assert suffix in ["vcf", "vcf.gz", "bcf", "bcf.gz"]
-    def create_cmd = suffix.endsWith(".gz") ? "echo '' | gzip >" : "touch"
+    def create_cmd = suffix.endsWith(".gz") ? 'echo "" | gzip >' : "touch"
     """
     ${create_cmd} ${prefix}.${suffix}
     """

--- a/modules/nf-core/shapeit5/ligate/tests/main.nf.test
+++ b/modules/nf-core/shapeit5/ligate/tests/main.nf.test
@@ -37,7 +37,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = BCFTOOLS_VIEW.out.vcf.join(BCFTOOLS_VIEW.out.csi)
+                input[0] = BCFTOOLS_VIEW.out.vcf.join(BCFTOOLS_VIEW.out.index)
                     .map{ meta, vcf, index -> [meta.subMap("id"), vcf, index]}
                     .groupTuple()
                 input[1] = ''

--- a/modules/nf-core/shapeit5/phasecommon/main.nf
+++ b/modules/nf-core/shapeit5/phasecommon/main.nf
@@ -3,9 +3,9 @@ process SHAPEIT5_PHASECOMMON {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/shapeit5:5.1.1--hb60d31d_0'
-        : 'biocontainers/shapeit5:5.1.1--hb60d31d_0'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fa/fa06870e893f9045944461e5b674adffec6deec41e8496b63ec54d44a98d6134/data'
+        : 'community.wave.seqera.io/library/shapeit5:5.1.1--09a6cb254ece8f6e'}"
 
     input:
     tuple val(meta), path(input), path(input_index), path(pedigree), val(region), path(reference), path(reference_index), path(scaffold), path(scaffold_index), path(map)

--- a/modules/nf-core/vcflib/vcffixup/environment.yml
+++ b/modules/nf-core/vcflib/vcffixup/environment.yml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
+  - bioconda::bcftools=1.23.1
   - bioconda::vcflib=1.0.14

--- a/modules/nf-core/vcflib/vcffixup/main.nf
+++ b/modules/nf-core/vcflib/vcffixup/main.nf
@@ -3,7 +3,7 @@ process VCFLIB_VCFFIXUP {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/16/169e4e28f26469eb05baf60eab777bccadd747ac75038c6bb22149cd40c2ff38/data':
         'community.wave.seqera.io/library/bcftools_vcflib:0b47030679d1eff1' }"
 
@@ -12,8 +12,10 @@ process VCFLIB_VCFFIXUP {
 
     output:
     tuple val(meta), path("*.{vcf,bcf}{,.gz}"), emit: vcf
-    tuple val("${task.process}"), val('vcflib'), val("1.0.14"), topic: versions, emit: versions_vcflib
+    tuple val(meta), path("*.{csi,tbi}")      , emit: index, optional: true
     // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    tuple val("${task.process}"), val('vcflib'), val("1.0.14"), topic: versions, emit: versions_vcflib
+    tuple val("${task.process}"), val('bcftools'), eval("bcftools --version | sed '1!d; s/^.*bcftools //'"), topic: versions, emit: versions_bcftools
 
     when:
     task.ext.when == null || task.ext.when
@@ -23,25 +25,56 @@ process VCFLIB_VCFFIXUP {
     def args2   = task.ext.args2  ?: ''
     def prefix  = task.ext.prefix ?: "${meta.id}.fixed"
 
-    if ( "$vcf" == "${prefix}.vcf.gz" ) {
+    def extension = args2.contains("--output-type b") || args2.contains("-Ob")
+        ? "bcf.gz"
+        : args2.contains("--output-type u") || args2.contains("-Ou")
+            ? "bcf"
+            : args2.contains("--output-type z") || args2.contains("-Oz")
+                ? "vcf.gz"
+                : args2.contains("--output-type v") || args2.contains("-Ov")
+                    ? "vcf"
+                    : "vcf"
+
+    if ( "${vcf}" == "${prefix}.${extension}" ) {
         error "Input and output names are the same, set prefix in module configuration to disambiguate!"
     }
 
     """
     vcffixup \\
-        $args \\
-        $vcf \\
-        | bcftools view -Ob -o ${prefix}.bcf
+        ${args} \\
+        ${vcf} \\
+        | bcftools view ${args2} -o ${prefix}.${extension}
     """
 
     stub:
     def prefix  = task.ext.prefix ?: "${meta.id}.fixed"
+    def args2   = task.ext.args2  ?: ''
+    def extension = args2.contains("--output-type b") || args2.contains("-Ob")
+        ? "bcf.gz"
+        : args2.contains("--output-type u") || args2.contains("-Ou")
+            ? "bcf"
+            : args2.contains("--output-type z") || args2.contains("-Oz")
+                ? "vcf.gz"
+                : args2.contains("--output-type v") || args2.contains("-Ov")
+                    ? "vcf"
+                    : "vcf"
+    def stub_index = args2.contains("--write-index=tbi") || args2.contains("-W=tbi")
+        ? "tbi"
+        : args2.contains("--write-index=csi") || args2.contains("-W=csi")
+            ? "csi"
+            : args2.contains("--write-index") || args2.contains("-W")
+                ? "csi"
+                : ""
 
-    if ( "$vcf" == "${prefix}.vcf.gz" ) {
+    if ( "${vcf}" == "${prefix}.${extension}" ) {
         error "Input and output names are the same, set prefix in module configuration to disambiguate!"
     }
 
+    def create_cmd = extension.endsWith(".gz") ? "echo '' | gzip >" : "touch"
+    def create_index = extension.endsWith(".gz") && stub_index.matches("csi|tbi") ? "touch ${prefix}.${extension}.${stub_index}" : ""
+
     """
-    echo | gzip > ${prefix}.vcf.gz
+    ${create_cmd} ${prefix}.${extension}
+    ${create_index}
     """
 }

--- a/modules/nf-core/vcflib/vcffixup/main.nf
+++ b/modules/nf-core/vcflib/vcffixup/main.nf
@@ -4,14 +4,14 @@ process VCFLIB_VCFFIXUP {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fc/fc33d59c090cef123aca26ae17fbddbd596640304d8325cbd5816229fa2c05ee/data':
-        'community.wave.seqera.io/library/vcflib:1.0.14--cc8ffb2c1a080797' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/16/169e4e28f26469eb05baf60eab777bccadd747ac75038c6bb22149cd40c2ff38/data':
+        'community.wave.seqera.io/library/bcftools_vcflib:0b47030679d1eff1' }"
 
     input:
     tuple val(meta), path(vcf), path(tbi)
 
     output:
-    tuple val(meta), path("*.vcf.gz"), emit: vcf
+    tuple val(meta), path("*.{vcf,bcf}{,.gz}"), emit: vcf
     tuple val("${task.process}"), val('vcflib'), val("1.0.14"), topic: versions, emit: versions_vcflib
     // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
 
@@ -31,7 +31,7 @@ process VCFLIB_VCFFIXUP {
     vcffixup \\
         $args \\
         $vcf \\
-        | bgzip -c $args2 > ${prefix}.vcf.gz
+        | bcftools view -Ob -o ${prefix}.bcf
     """
 
     stub:

--- a/modules/nf-core/vcflib/vcffixup/meta.yml
+++ b/modules/nf-core/vcflib/vcffixup/meta.yml
@@ -1,6 +1,6 @@
 name: "vcflib_vcffixup"
-description: Generates a VCF stream where AC and NS have been generated for each record
-  using sample genotypes.
+description: Generates a VCF stream where AC and NS have been generated for each
+  record using sample genotypes.
 keywords:
   - vcf
   - vcflib
@@ -12,8 +12,25 @@ tools:
       homepage: https://github.com/vcflib/vcflib
       documentation: https://github.com/vcflib/vcflib#USAGE
       doi: "10.1101/2021.05.21.445151"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:vcflib
+  - bcftools:
+      description: BCFtools is a set of utilities that manipulate variant calls in
+        the Variant Call Format (VCF) and its binary counterpart BCF. All commands
+        work transparently with both VCFs and BCFs, both uncompressed and
+        BGZF-compressed.  Most commands accept VCF, bgzipped VCF and BCF with
+        filetype detected automatically even when streaming from a pipe. Indexed
+        VCF and BCF will work in all situations. Un-indexed VCF and BCF and
+        streams will work in most, but not all situations.
+      homepage: https://samtools.github.io/bcftools/
+      documentation: https://samtools.github.io/bcftools/howtos/index.html
+      tool_dev_url: https://github.com/samtools/bcftools
+      doi: "10.1093/gigascience/giab008"
+      licence:
+        - "MIT"
+        - "GPL-3.0-or-later"
+      identifier: biotools:bcftools
 input:
   - - meta:
         type: map
@@ -37,12 +54,23 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*.vcf.gz":
+      - "*.{vcf,bcf}{,.gz}":
           type: file
-          description: Compressed VCF file
-          pattern: "*.vcf.gz"
+          description: Compressed or not VCF or BCF file
+          pattern: "*.{vcf,bcf}{,.gz}"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
+  index:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.{csi,tbi}":
+          type: file
+          description: Index file
+          pattern: "*.{csi,tbi}"
+          ontologies: []
   versions_vcflib:
     - - ${task.process}:
           type: string
@@ -53,6 +81,16 @@ output:
       - 1.0.14:
           type: string
           description: The expression to obtain the version of the tool
+  versions_bcftools:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bcftools:
+          type: string
+          description: The tool name
+      - "bcftools --version | sed '1!d; s/^.*bcftools //'":
+          type: eval
+          description: The command used to generate the version of the tool
 topics:
   versions:
     - - ${task.process}:
@@ -64,6 +102,15 @@ topics:
       - 1.0.14:
           type: string
           description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bcftools:
+          type: string
+          description: The tool name
+      - "bcftools --version | sed '1!d; s/^.*bcftools //'":
+          type: eval
+          description: The command used to generate the version of the tool
 authors:
   - "@atrigila"
 maintainers:

--- a/modules/nf-core/vcflib/vcffixup/tests/main.nf.test
+++ b/modules/nf-core/vcflib/vcffixup/tests/main.nf.test
@@ -2,6 +2,7 @@ nextflow_process {
 
     name "Test Process VCFLIB_VCFFIXUP"
     script "../main.nf"
+    config "./nextflow.config"
     process "VCFLIB_VCFFIXUP"
 
     tag "modules"
@@ -9,9 +10,70 @@ nextflow_process {
     tag "vcflib"
     tag "vcflib/vcffixup"
 
-    test("test-vcflib-vcffixup") {
+    test("test-vcflib-vcffixup - vcf.gz - no index") {
 
         when {
+            params{
+                vcffixup_args = ""
+                bcftools_args = "-Oz"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    sanitizeOutput(process.out, unstableKeys:["vcf", "index"]),
+                    path(process.out.vcf[0][1]).vcf.variantsMD5
+                ).match() }
+            )
+        }
+    }
+
+    test("test-vcflib-vcffixup - bcf.gz - csi") {
+
+        when {
+            params{
+                vcffixup_args = ""
+                bcftools_args = "-Ob --write-index=csi"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["vcf", "index"])).match() }
+            )
+        }
+    }
+
+    test("test-vcflib-vcffixup - vcf.gz - no index -- stub") {
+
+        options "-stub"
+
+        when {
+            params{
+                vcffixup_args = ""
+                bcftools_args = ""
+            }
             process {
                 """
                 input[0] = [
@@ -31,11 +93,15 @@ nextflow_process {
         }
     }
 
-    test("test-vcflib-vcffixup-stub") {
+    test("test-vcflib-vcffixup - bcf.gz - csi -- stub") {
 
         options "-stub"
 
         when {
+            params{
+                vcffixup_args = ""
+                bcftools_args = "-Ob --write-index=csi"
+            }
             process {
                 """
                 input[0] = [

--- a/modules/nf-core/vcflib/vcffixup/tests/main.nf.test.snap
+++ b/modules/nf-core/vcflib/vcffixup/tests/main.nf.test.snap
@@ -1,13 +1,28 @@
 {
-    "test-vcflib-vcffixup-stub": {
+    "test-vcflib-vcffixup - bcf.gz - csi": {
         "content": [
             {
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fixed.bcf.gz.csi"
+                    ]
+                ],
                 "vcf": [
                     [
                         {
                             "id": "test"
                         },
-                        "test.fixed.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "test.fixed.bcf.gz"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "VCFLIB_VCFFIXUP",
+                        "bcftools",
+                        "1.23.1"
                     ]
                 ],
                 "versions_vcflib": [
@@ -19,21 +34,73 @@
                 ]
             }
         ],
+        "timestamp": "2026-06-11T12:07:48.593489406",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-02T22:37:54.793666638"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     },
-    "test-vcflib-vcffixup": {
+    "test-vcflib-vcffixup - vcf.gz - no index": {
         "content": [
             {
+                "index": [
+                    
+                ],
                 "vcf": [
                     [
                         {
                             "id": "test"
                         },
-                        "test.fixed.vcf.gz:md5,accef1928d58d5c20553096921a9b1f6"
+                        "test.fixed.vcf.gz"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "VCFLIB_VCFFIXUP",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "versions_vcflib": [
+                    [
+                        "VCFLIB_VCFFIXUP",
+                        "vcflib",
+                        "1.0.14"
+                    ]
+                ]
+            },
+            "129354635f189827c91335aab65b084"
+        ],
+        "timestamp": "2026-06-11T12:02:59.061677752",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
+    },
+    "test-vcflib-vcffixup - bcf.gz - csi -- stub": {
+        "content": [
+            {
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fixed.bcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fixed.bcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "VCFLIB_VCFFIXUP",
+                        "bcftools",
+                        "1.23.1"
                     ]
                 ],
                 "versions_vcflib": [
@@ -45,10 +112,46 @@
                 ]
             }
         ],
+        "timestamp": "2026-06-11T12:01:28.475608083",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-02T22:37:48.442953709"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
+    },
+    "test-vcflib-vcffixup - vcf.gz - no index -- stub": {
+        "content": [
+            {
+                "index": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fixed.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "VCFLIB_VCFFIXUP",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "versions_vcflib": [
+                    [
+                        "VCFLIB_VCFFIXUP",
+                        "vcflib",
+                        "1.0.14"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-11T11:59:00.129497907",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     }
 }

--- a/modules/nf-core/vcflib/vcffixup/tests/nextflow.config
+++ b/modules/nf-core/vcflib/vcffixup/tests/nextflow.config
@@ -1,0 +1,6 @@
+process {
+    withName: VCFLIB_VCFFIXUP {
+        ext.args = params.vcffixup_args
+        ext.args2  = params.bcftools_args
+    }
+}

--- a/subworkflows/local/vcf_normalize_bcftools/main.nf
+++ b/subworkflows/local/vcf_normalize_bcftools/main.nf
@@ -1,7 +1,6 @@
 include { BCFTOOLS_NORM   } from '../../../modules/nf-core/bcftools/norm'
 include { BCFTOOLS_VIEW   } from '../../../modules/nf-core/bcftools/view'
 include { VCFLIB_VCFFIXUP } from '../../../modules/nf-core/vcflib/vcffixup/main'
-include { BCFTOOLS_INDEX  } from '../../../modules/nf-core/bcftools/index'
 
 workflow VCF_NORMALIZE_BCFTOOLS {
     take:
@@ -42,16 +41,9 @@ workflow VCF_NORMALIZE_BCFTOOLS {
     if (compute_freq) {
         VCFLIB_VCFFIXUP(ch_vcf_tbi)
 
-        // Index fixed panel
-        BCFTOOLS_INDEX(VCFLIB_VCFFIXUP.out.vcf)
-
         // Join fixed vcf and tbi
         ch_vcf_tbi = VCFLIB_VCFFIXUP.out.vcf
-            .join(
-                BCFTOOLS_INDEX.out.tbi.mix(
-                    BCFTOOLS_INDEX.out.csi
-                )
-            )
+            .join(VCFLIB_VCFFIXUP.out.index)
     }
     emit:
     vcf_tbi        = ch_vcf_tbi                     // channel: [ [id, chr], vcf, tbi ]

--- a/subworkflows/local/vcf_normalize_bcftools/main.nf
+++ b/subworkflows/local/vcf_normalize_bcftools/main.nf
@@ -20,14 +20,22 @@ workflow VCF_NORMALIZE_BCFTOOLS {
 
         // Join multiallelic VCF and TBI
         ch_multiallelic_vcf_tbi = BCFTOOLS_NORM.out.vcf
-            .join(BCFTOOLS_NORM.out.tbi)
+            .join(
+                BCFTOOLS_NORM.out.tbi.mix(
+                    BCFTOOLS_NORM.out.csi
+                )
+            )
 
         // Remove all multiallelic records and samples specified in the `--remove_samples` command:
         BCFTOOLS_VIEW(ch_multiallelic_vcf_tbi, [], [], [])
 
         // Join biallelic VCF and TBI
         ch_vcf_tbi = BCFTOOLS_VIEW.out.vcf
-            .join(BCFTOOLS_VIEW.out.tbi)
+            .join(
+                BCFTOOLS_VIEW.out.tbi.mix(
+                    BCFTOOLS_VIEW.out.csi
+                )
+            )
     }
 
     // (Optional) Fix panel (When AC/AN INFO fields in VCF are inconsistent with GT field)
@@ -39,7 +47,11 @@ workflow VCF_NORMALIZE_BCFTOOLS {
 
         // Join fixed vcf and tbi
         ch_vcf_tbi = VCFLIB_VCFFIXUP.out.vcf
-            .join(BCFTOOLS_INDEX.out.tbi)
+            .join(
+                BCFTOOLS_INDEX.out.tbi.mix(
+                    BCFTOOLS_INDEX.out.csi
+                )
+            )
     }
     emit:
     vcf_tbi        = ch_vcf_tbi                     // channel: [ [id, chr], vcf, tbi ]

--- a/subworkflows/local/vcf_normalize_bcftools/meta.yml
+++ b/subworkflows/local/vcf_normalize_bcftools/meta.yml
@@ -13,7 +13,6 @@ components:
   - bcftools/norm
   - bcftools/view
   - vcflib/vcffixup
-  - bcftools/index
 input:
   - ch_vcf:
       type: file

--- a/subworkflows/local/vcf_normalize_bcftools/tests/main.nf.test
+++ b/subworkflows/local/vcf_normalize_bcftools/tests/main.nf.test
@@ -15,7 +15,6 @@ nextflow_workflow {
     tag "bcftools"
     tag "bcftools/norm"
     tag "bcftools/view"
-    tag "bcftools/index"
     tag "vcflib"
     tag "vcflib/vcffixup"
 

--- a/subworkflows/local/vcf_normalize_bcftools/tests/nextflow.config
+++ b/subworkflows/local/vcf_normalize_bcftools/tests/nextflow.config
@@ -15,9 +15,6 @@ process {
 
     withName: VCFLIB_VCFFIXUP {
         ext.prefix   = { "${meta.id}_${meta.chr}" }
-    }
-
-    withName: BCFTOOLS_INDEX {
-        ext.args     = "--tbi"
+        ext.args2    = "--output-type z --write-index=tbi"
     }
 }

--- a/tests/lib/UTILS.groovy
+++ b/tests/lib/UTILS.groovy
@@ -8,7 +8,7 @@ class UTILS {
         // bam_files: All bam files
         def bam_files   = getAllFilesFromDir(outdir, include: ['**/*.bam'])
         // vcf_files: All vcf files
-        def vcf_files   = getAllFilesFromDir(outdir, include: ['**/*.{vcf,bcf}.gz'])
+        def vcf_files   = getAllFilesFromDir(outdir, include: ['**/*.vcf.gz'])
         // csv_files: All csv files
         def csv_files   = getAllFilesFromDir(outdir, include: ['**/*.csv'])
         return [

--- a/workflows/phaseimpute/tests/nextflow.config
+++ b/workflows/phaseimpute/tests/nextflow.config
@@ -1,4 +1,10 @@
 process {
+    withName: 'NFCORE_PHASEIMPUTE:PHASEIMPUTE:VCF_PHASE_SHAPEIT5:SHAPEIT5_LIGATE' {
+        cpus       = 1
+        ext.args   = {"--seed ${params.seed}"}
+        ext.prefix = { "${meta.panel_id}_${meta.chr}_phased" }
+    }
+
     withName: 'NFCORE_PHASEIMPUTE:PHASEIMPUTE:VCF_PHASE_SHAPEIT5:SHAPEIT5_PHASECOMMON' {
         cpus       = 1
         ext.args   = {"--seed ${params.seed}"}

--- a/workflows/phaseimpute/tests/test_all.nf.test.snap
+++ b/workflows/phaseimpute/tests/test_all.nf.test.snap
@@ -2,7 +2,7 @@
     "Check test_all - no map - no chunks": {
         "content": [
             {
-                "workflow size": 245,
+                "workflow size": 243,
                 "versions": {
                     "ADDCOLUMNS": {
                         "gawk": "5.3.1"
@@ -965,7 +965,7 @@
                 }
             }
         ],
-        "timestamp": "2026-06-11T15:23:35.53328575",
+        "timestamp": "2026-06-11T15:50:19.452278191",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
@@ -974,7 +974,7 @@
     "Check test_all - with map - no chunks": {
         "content": [
             {
-                "workflow size": 247,
+                "workflow size": 245,
                 "versions": {
                     "ADDCOLUMNS": {
                         "gawk": "5.3.1"
@@ -1959,7 +1959,7 @@
                 }
             }
         ],
-        "timestamp": "2026-06-11T15:25:48.633078283",
+        "timestamp": "2026-06-11T15:52:34.630763476",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"

--- a/workflows/phaseimpute/tests/test_all.nf.test.snap
+++ b/workflows/phaseimpute/tests/test_all.nf.test.snap
@@ -980,10 +980,10 @@
                 }
             }
         ],
-        "timestamp": "2026-05-17T14:04:03.385347374",
+        "timestamp": "2026-06-10T16:33:54.425766934",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.1"
         }
     },
     "Check test_all - with map - no chunks": {

--- a/workflows/phaseimpute/tests/test_all.nf.test.snap
+++ b/workflows/phaseimpute/tests/test_all.nf.test.snap
@@ -158,6 +158,7 @@
                         "bcftools": "1.22"
                     },
                     "VCFLIB_VCFFIXUP": {
+                        "bcftools": "1.23.1",
                         "vcflib": "1.0.14"
                     },
                     "Workflow": {
@@ -457,24 +458,24 @@
                     "prep_panel/panel/1000GP_chr21_16570070-16590513_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf.csi",
-                    "prep_panel/panel/1000GP_chr21_fixup.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_fixup.vcf.gz.tbi",
-                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr21_fixup.bcf.gz",
+                    "prep_panel/panel/1000GP_chr21_fixup.bcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr21_multiallelic.bcf.gz",
+                    "prep_panel/panel/1000GP_chr21_multiallelic.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_normalized.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_normalized.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr21_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_16570065-16592216_chunks.bcf",
                     "prep_panel/panel/1000GP_chr22_16570065-16592216_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf.csi",
-                    "prep_panel/panel/1000GP_chr22_fixup.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_fixup.vcf.gz.tbi",
-                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr22_fixup.bcf.gz",
+                    "prep_panel/panel/1000GP_chr22_fixup.bcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr22_multiallelic.bcf.gz",
+                    "prep_panel/panel/1000GP_chr22_multiallelic.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_normalized.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_normalized.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr22_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz.csi",
                     "prep_panel/posfile",
@@ -835,28 +836,12 @@
                         "29427a4627341255077971f1876ba1d5"
                     ],
                     [
-                        "1000GP_chr21_fixup.vcf.gz",
-                        "1a7f840b5311e45cad2210779cc90d7e"
-                    ],
-                    [
-                        "1000GP_chr21_multiallelic.vcf.gz",
-                        "1a7f840b5311e45cad2210779cc90d7e"
-                    ],
-                    [
                         "1000GP_chr21_normalized.vcf.gz",
                         "1a7f840b5311e45cad2210779cc90d7e"
                     ],
                     [
                         "1000GP_chr21_phased.vcf.gz",
                         "797b0fd345ce761987d4b3bddac4236a"
-                    ],
-                    [
-                        "1000GP_chr22_fixup.vcf.gz",
-                        "e028aaa747cdb57516927d6dbd849ead"
-                    ],
-                    [
-                        "1000GP_chr22_multiallelic.vcf.gz",
-                        "e028aaa747cdb57516927d6dbd849ead"
                     ],
                     [
                         "1000GP_chr22_normalized.vcf.gz",
@@ -980,7 +965,7 @@
                 }
             }
         ],
-        "timestamp": "2026-06-10T16:33:54.425766934",
+        "timestamp": "2026-06-11T15:23:35.53328575",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
@@ -1150,6 +1135,7 @@
                         "bcftools": "1.22"
                     },
                     "VCFLIB_VCFFIXUP": {
+                        "bcftools": "1.23.1",
                         "vcflib": "1.0.14"
                     },
                     "Workflow": {
@@ -1458,24 +1444,24 @@
                     "prep_panel/panel/1000GP_chr21_16570070-16590513_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf.csi",
-                    "prep_panel/panel/1000GP_chr21_fixup.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_fixup.vcf.gz.tbi",
-                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr21_fixup.bcf.gz",
+                    "prep_panel/panel/1000GP_chr21_fixup.bcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr21_multiallelic.bcf.gz",
+                    "prep_panel/panel/1000GP_chr21_multiallelic.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_normalized.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_normalized.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr21_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_16570065-16592216_chunks.bcf",
                     "prep_panel/panel/1000GP_chr22_16570065-16592216_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf.csi",
-                    "prep_panel/panel/1000GP_chr22_fixup.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_fixup.vcf.gz.tbi",
-                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr22_fixup.bcf.gz",
+                    "prep_panel/panel/1000GP_chr22_fixup.bcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr22_multiallelic.bcf.gz",
+                    "prep_panel/panel/1000GP_chr22_multiallelic.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_normalized.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_normalized.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr22_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz.csi",
                     "prep_panel/posfile",
@@ -1844,28 +1830,12 @@
                         "29427a4627341255077971f1876ba1d5"
                     ],
                     [
-                        "1000GP_chr21_fixup.vcf.gz",
-                        "1a7f840b5311e45cad2210779cc90d7e"
-                    ],
-                    [
-                        "1000GP_chr21_multiallelic.vcf.gz",
-                        "1a7f840b5311e45cad2210779cc90d7e"
-                    ],
-                    [
                         "1000GP_chr21_normalized.vcf.gz",
                         "1a7f840b5311e45cad2210779cc90d7e"
                     ],
                     [
                         "1000GP_chr21_phased.vcf.gz",
                         "c848bc7161431a962bc9d08c7b009e65"
-                    ],
-                    [
-                        "1000GP_chr22_fixup.vcf.gz",
-                        "e028aaa747cdb57516927d6dbd849ead"
-                    ],
-                    [
-                        "1000GP_chr22_multiallelic.vcf.gz",
-                        "e028aaa747cdb57516927d6dbd849ead"
                     ],
                     [
                         "1000GP_chr22_normalized.vcf.gz",
@@ -1989,10 +1959,10 @@
                 }
             }
         ],
-        "timestamp": "2026-05-17T15:26:51.457738966",
+        "timestamp": "2026-06-11T15:25:48.633078283",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.1"
         }
     }
 }

--- a/workflows/phaseimpute/tests/test_panelprep.nf.test
+++ b/workflows/phaseimpute/tests/test_panelprep.nf.test
@@ -9,7 +9,6 @@ nextflow_pipeline {
     config "./nextflow.config"
 
     test("Check test_panelprep - no map - no chunks") {
-        tag "test1"
         config "../../../conf/test_panelprep.config"
         when {
             params {

--- a/workflows/phaseimpute/tests/test_panelprep.nf.test
+++ b/workflows/phaseimpute/tests/test_panelprep.nf.test
@@ -9,6 +9,7 @@ nextflow_pipeline {
     config "./nextflow.config"
 
     test("Check test_panelprep - no map - no chunks") {
+        tag "test1"
         config "../../../conf/test_panelprep.config"
         when {
             params {

--- a/workflows/phaseimpute/tests/test_panelprep.nf.test.snap
+++ b/workflows/phaseimpute/tests/test_panelprep.nf.test.snap
@@ -90,8 +90,8 @@
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz",
                     "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz.csi",
-                    "prep_panel/panel/1000GP_chr21_normalized.bcf.gz",
-                    "prep_panel/panel/1000GP_chr21_normalized.bcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr21_normalized.vcf.gz",
+                    "prep_panel/panel/1000GP_chr21_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_16570065-16592216_chunks.bcf",
@@ -100,8 +100,8 @@
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz",
                     "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz.csi",
-                    "prep_panel/panel/1000GP_chr22_normalized.bcf.gz",
-                    "prep_panel/panel/1000GP_chr22_normalized.bcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr22_normalized.vcf.gz",
+                    "prep_panel/panel/1000GP_chr22_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz.csi",
                     "prep_panel/posfile",
@@ -143,12 +143,20 @@
                         "1a7f840b5311e45cad2210779cc90d7e"
                     ],
                     [
+                        "1000GP_chr21_normalized.vcf.gz",
+                        "a8e65435a4392c209107497bf3c31d5a"
+                    ],
+                    [
                         "1000GP_chr21_phased.vcf.gz",
                         "52bcbe4476db8398ac7c5cf3ce089a50"
                     ],
                     [
                         "1000GP_chr22_multiallelic.vcf.gz",
                         "e028aaa747cdb57516927d6dbd849ead"
+                    ],
+                    [
+                        "1000GP_chr22_normalized.vcf.gz",
+                        "78893f1a3bce8bd1090069c7f4000a1"
                     ],
                     [
                         "1000GP_chr22_phased.vcf.gz",
@@ -189,9 +197,17 @@
                         ]
                     }
                 ]
+            },
+            {
+                "phased_panel_chr21": {
+                    "summary": "VcfFile [chromosomes=[chr21], sampleCount=3192, variantCount=836, phased=true]"
+                },
+                "phased_panel_chr22": {
+                    "summary": "VcfFile [chromosomes=[chr22], sampleCount=3192, variantCount=903, phased=true]"
+                }
             }
         ],
-        "timestamp": "2026-06-10T22:31:05.187191359",
+        "timestamp": "2026-06-11T15:08:32.472371737",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
@@ -200,12 +216,9 @@
     "Check test_panelprep - with map - with chunks": {
         "content": [
             {
-                "workflow size": 34,
+                "workflow size": 30,
                 "versions": {
                     "BCFTOOLS_CONVERT": {
-                        "bcftools": "1.23.1"
-                    },
-                    "BCFTOOLS_INDEX": {
                         "bcftools": "1.23.1"
                     },
                     "BCFTOOLS_INDEX_LIGATE": {
@@ -242,9 +255,6 @@
                     },
                     "VCFCHREXTRACT": {
                         "bcftools": "1.22"
-                    },
-                    "VCFLIB_VCFFIXUP": {
-                        "vcflib": "1.0.14"
                     },
                     "Workflow": {
                         "nf-core/phaseimpute": "v1.2.0dev"
@@ -292,24 +302,20 @@
                     "prep_panel/panel/1000GP_chr21_16570070-16590513_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf.csi",
-                    "prep_panel/panel/1000GP_chr21_fixup.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_fixup.vcf.gz.tbi",
                     "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_normalized.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_normalized.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr21_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_16570065-16592216_chunks.bcf",
                     "prep_panel/panel/1000GP_chr22_16570065-16592216_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf.csi",
-                    "prep_panel/panel/1000GP_chr22_fixup.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_fixup.vcf.gz.tbi",
                     "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_normalized.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_normalized.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr22_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz.csi",
                     "prep_panel/posfile",
@@ -335,12 +341,12 @@
                     "GRCh38.s.fa.gz.fai:md5,4f4e0ff133e7a05cb469e345f766ca8c",
                     "GRCh38.s.fa.gz.gzi:md5,09046d9646db2cc5c425f231ce4595d7",
                     "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
-                    "1000GP_chr21.hap.gz:md5,64d7fdfc96ce79848cf9c3c220e6774f",
+                    "1000GP_chr21.hap.gz:md5,d18ac86ed7080c6527aade3b6717ebb0",
                     "1000GP_chr21.legend.gz:md5,3f7edc4c153521a0871c9d51f7da2372",
-                    "1000GP_chr21.samples:md5,d8ca3e8336976001de8df6be7ae236cb",
-                    "1000GP_chr22.hap.gz:md5,9500b831dcfee86a98577dde9e2cce73",
+                    "1000GP_chr21.samples:md5,ba53fdcb71cd6dbd218e0e932555086c",
+                    "1000GP_chr22.hap.gz:md5,40b908abc098ef9919f80b90a79f8c6c",
                     "1000GP_chr22.legend.gz:md5,82f6f97f61e68b4872cc14c0125ff037",
-                    "1000GP_chr22.samples:md5,d8ca3e8336976001de8df6be7ae236cb",
+                    "1000GP_chr22.samples:md5,ba53fdcb71cd6dbd218e0e932555086c",
                     "1000GP.chr21.posfile.txt.gz:md5,33d064c5132000799f3df9ea31967e12",
                     "1000GP.chr22.posfile.txt.gz:md5,f5997df5995dcdbc4ab31e1084b83541",
                     "1000GP.chr21.posfile.txt:md5,33d064c5132000799f3df9ea31967e12",
@@ -351,24 +357,16 @@
                 ],
                 "VCF files": [
                     [
-                        "1000GP_chr21_fixup.vcf.gz",
-                        "1a7f840b5311e45cad2210779cc90d7e"
-                    ],
-                    [
                         "1000GP_chr21_multiallelic.vcf.gz",
                         "1a7f840b5311e45cad2210779cc90d7e"
                     ],
                     [
                         "1000GP_chr21_normalized.vcf.gz",
-                        "1a7f840b5311e45cad2210779cc90d7e"
+                        "a8e65435a4392c209107497bf3c31d5a"
                     ],
                     [
                         "1000GP_chr21_phased.vcf.gz",
-                        "c848bc7161431a962bc9d08c7b009e65"
-                    ],
-                    [
-                        "1000GP_chr22_fixup.vcf.gz",
-                        "e028aaa747cdb57516927d6dbd849ead"
+                        "377fc1bc7cf1602b55833a2d2e3caa97"
                     ],
                     [
                         "1000GP_chr22_multiallelic.vcf.gz",
@@ -376,19 +374,19 @@
                     ],
                     [
                         "1000GP_chr22_normalized.vcf.gz",
-                        "e028aaa747cdb57516927d6dbd849ead"
+                        "78893f1a3bce8bd1090069c7f4000a1"
                     ],
                     [
                         "1000GP_chr22_phased.vcf.gz",
-                        "791ca241f3cd9b868a2d4492d3062f57"
+                        "546dc3c1f9b47c9a3aa568a55614881d"
                     ],
                     [
                         "1000GP_chr21_glimpse1_sites.vcf.gz",
-                        "6a6015e06338ef14f58749dd067f4a78"
+                        "10fe85184e0afaddc094cf8450551cca"
                     ],
                     [
                         "1000GP_chr22_glimpse1_sites.vcf.gz",
-                        "321a19489c56a5d670ee49b26d9052b9"
+                        "c8dade5436fccb3839877a0749f1a665"
                     ]
                 ],
                 "CSV files": [
@@ -409,12 +407,20 @@
                         ]
                     }
                 ]
+            },
+            {
+                "phased_panel_chr21": {
+                    "summary": "VcfFile [chromosomes=[chr21], sampleCount=3192, variantCount=836, phased=true]"
+                },
+                "phased_panel_chr22": {
+                    "summary": "VcfFile [chromosomes=[chr22], sampleCount=3192, variantCount=903, phased=true]"
+                }
             }
         ],
-        "timestamp": "2026-05-17T15:42:03.129095578",
+        "timestamp": "2026-06-11T15:09:12.506209545",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.1"
         }
     }
 }

--- a/workflows/phaseimpute/tests/test_panelprep.nf.test.snap
+++ b/workflows/phaseimpute/tests/test_panelprep.nf.test.snap
@@ -2,9 +2,12 @@
     "Check test_panelprep - no map - no chunks": {
         "content": [
             {
-                "workflow size": 32,
+                "workflow size": 36,
                 "versions": {
                     "BCFTOOLS_CONVERT": {
+                        "bcftools": "1.23.1"
+                    },
+                    "BCFTOOLS_INDEX": {
                         "bcftools": "1.23.1"
                     },
                     "BCFTOOLS_INDEX_LIGATE": {
@@ -42,6 +45,10 @@
                     },
                     "VCFCHREXTRACT": {
                         "bcftools": "1.22"
+                    },
+                    "VCFLIB_VCFFIXUP": {
+                        "bcftools": "1.23.1",
+                        "vcflib": "1.0.14"
                     },
                     "Workflow": {
                         "nf-core/phaseimpute": "v1.2.0dev"
@@ -88,6 +95,8 @@
                     "prep_panel/panel/1000GP_chr21_16570070-16590513_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf.csi",
+                    "prep_panel/panel/1000GP_chr21_fixup.bcf.gz",
+                    "prep_panel/panel/1000GP_chr21_fixup.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz",
                     "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_normalized.vcf.gz",
@@ -98,6 +107,8 @@
                     "prep_panel/panel/1000GP_chr22_16570065-16592216_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf.csi",
+                    "prep_panel/panel/1000GP_chr22_fixup.bcf.gz",
+                    "prep_panel/panel/1000GP_chr22_fixup.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz",
                     "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_normalized.vcf.gz",
@@ -164,11 +175,11 @@
                     ],
                     [
                         "1000GP_chr21_glimpse1_sites.vcf.gz",
-                        "10fe85184e0afaddc094cf8450551cca"
+                        "3d0567b5bceed75b88b1ab565760d096"
                     ],
                     [
                         "1000GP_chr22_glimpse1_sites.vcf.gz",
-                        "c8dade5436fccb3839877a0749f1a665"
+                        "a3302d6003d28cc83772a995a5c764c2"
                     ]
                 ],
                 "CSV files": [
@@ -207,7 +218,7 @@
                 }
             }
         ],
-        "timestamp": "2026-06-11T15:08:32.472371737",
+        "timestamp": "2026-06-11T15:14:35.629338747",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
@@ -216,9 +227,12 @@
     "Check test_panelprep - with map - with chunks": {
         "content": [
             {
-                "workflow size": 30,
+                "workflow size": 34,
                 "versions": {
                     "BCFTOOLS_CONVERT": {
+                        "bcftools": "1.23.1"
+                    },
+                    "BCFTOOLS_INDEX": {
                         "bcftools": "1.23.1"
                     },
                     "BCFTOOLS_INDEX_LIGATE": {
@@ -255,6 +269,10 @@
                     },
                     "VCFCHREXTRACT": {
                         "bcftools": "1.22"
+                    },
+                    "VCFLIB_VCFFIXUP": {
+                        "bcftools": "1.23.1",
+                        "vcflib": "1.0.14"
                     },
                     "Workflow": {
                         "nf-core/phaseimpute": "v1.2.0dev"
@@ -302,6 +320,8 @@
                     "prep_panel/panel/1000GP_chr21_16570070-16590513_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf.csi",
+                    "prep_panel/panel/1000GP_chr21_fixup.bcf.gz",
+                    "prep_panel/panel/1000GP_chr21_fixup.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz",
                     "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_normalized.vcf.gz",
@@ -312,6 +332,8 @@
                     "prep_panel/panel/1000GP_chr22_16570065-16592216_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf.csi",
+                    "prep_panel/panel/1000GP_chr22_fixup.bcf.gz",
+                    "prep_panel/panel/1000GP_chr22_fixup.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz",
                     "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_normalized.vcf.gz",
@@ -382,11 +404,11 @@
                     ],
                     [
                         "1000GP_chr21_glimpse1_sites.vcf.gz",
-                        "10fe85184e0afaddc094cf8450551cca"
+                        "3d0567b5bceed75b88b1ab565760d096"
                     ],
                     [
                         "1000GP_chr22_glimpse1_sites.vcf.gz",
-                        "c8dade5436fccb3839877a0749f1a665"
+                        "a3302d6003d28cc83772a995a5c764c2"
                     ]
                 ],
                 "CSV files": [
@@ -417,7 +439,7 @@
                 }
             }
         ],
-        "timestamp": "2026-06-11T15:09:12.506209545",
+        "timestamp": "2026-06-11T15:15:18.599055829",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"

--- a/workflows/phaseimpute/tests/test_panelprep.nf.test.snap
+++ b/workflows/phaseimpute/tests/test_panelprep.nf.test.snap
@@ -2,12 +2,9 @@
     "Check test_panelprep - no map - no chunks": {
         "content": [
             {
-                "workflow size": 36,
+                "workflow size": 34,
                 "versions": {
                     "BCFTOOLS_CONVERT": {
-                        "bcftools": "1.23.1"
-                    },
-                    "BCFTOOLS_INDEX": {
                         "bcftools": "1.23.1"
                     },
                     "BCFTOOLS_INDEX_LIGATE": {
@@ -97,8 +94,8 @@
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr21_fixup.bcf.gz",
                     "prep_panel/panel/1000GP_chr21_fixup.bcf.gz.csi",
-                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr21_multiallelic.bcf.gz",
+                    "prep_panel/panel/1000GP_chr21_multiallelic.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_normalized.vcf.gz",
                     "prep_panel/panel/1000GP_chr21_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz",
@@ -109,8 +106,8 @@
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr22_fixup.bcf.gz",
                     "prep_panel/panel/1000GP_chr22_fixup.bcf.gz.csi",
-                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr22_multiallelic.bcf.gz",
+                    "prep_panel/panel/1000GP_chr22_multiallelic.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_normalized.vcf.gz",
                     "prep_panel/panel/1000GP_chr22_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz",
@@ -150,20 +147,12 @@
                 ],
                 "VCF files": [
                     [
-                        "1000GP_chr21_multiallelic.vcf.gz",
-                        "1a7f840b5311e45cad2210779cc90d7e"
-                    ],
-                    [
                         "1000GP_chr21_normalized.vcf.gz",
                         "a8e65435a4392c209107497bf3c31d5a"
                     ],
                     [
                         "1000GP_chr21_phased.vcf.gz",
                         "52bcbe4476db8398ac7c5cf3ce089a50"
-                    ],
-                    [
-                        "1000GP_chr22_multiallelic.vcf.gz",
-                        "e028aaa747cdb57516927d6dbd849ead"
                     ],
                     [
                         "1000GP_chr22_normalized.vcf.gz",
@@ -218,7 +207,7 @@
                 }
             }
         ],
-        "timestamp": "2026-06-11T15:14:35.629338747",
+        "timestamp": "2026-06-11T15:53:36.17139211",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
@@ -227,12 +216,9 @@
     "Check test_panelprep - with map - with chunks": {
         "content": [
             {
-                "workflow size": 34,
+                "workflow size": 32,
                 "versions": {
                     "BCFTOOLS_CONVERT": {
-                        "bcftools": "1.23.1"
-                    },
-                    "BCFTOOLS_INDEX": {
                         "bcftools": "1.23.1"
                     },
                     "BCFTOOLS_INDEX_LIGATE": {
@@ -322,8 +308,8 @@
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr21_fixup.bcf.gz",
                     "prep_panel/panel/1000GP_chr21_fixup.bcf.gz.csi",
-                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr21_multiallelic.bcf.gz",
+                    "prep_panel/panel/1000GP_chr21_multiallelic.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_normalized.vcf.gz",
                     "prep_panel/panel/1000GP_chr21_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz",
@@ -334,8 +320,8 @@
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr22_fixup.bcf.gz",
                     "prep_panel/panel/1000GP_chr22_fixup.bcf.gz.csi",
-                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr22_multiallelic.bcf.gz",
+                    "prep_panel/panel/1000GP_chr22_multiallelic.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_normalized.vcf.gz",
                     "prep_panel/panel/1000GP_chr22_normalized.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz",
@@ -379,20 +365,12 @@
                 ],
                 "VCF files": [
                     [
-                        "1000GP_chr21_multiallelic.vcf.gz",
-                        "1a7f840b5311e45cad2210779cc90d7e"
-                    ],
-                    [
                         "1000GP_chr21_normalized.vcf.gz",
                         "a8e65435a4392c209107497bf3c31d5a"
                     ],
                     [
                         "1000GP_chr21_phased.vcf.gz",
                         "377fc1bc7cf1602b55833a2d2e3caa97"
-                    ],
-                    [
-                        "1000GP_chr22_multiallelic.vcf.gz",
-                        "e028aaa747cdb57516927d6dbd849ead"
                     ],
                     [
                         "1000GP_chr22_normalized.vcf.gz",
@@ -439,7 +417,7 @@
                 }
             }
         ],
-        "timestamp": "2026-06-11T15:15:18.599055829",
+        "timestamp": "2026-06-11T15:54:18.897975608",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"

--- a/workflows/phaseimpute/tests/test_panelprep.nf.test.snap
+++ b/workflows/phaseimpute/tests/test_panelprep.nf.test.snap
@@ -2,12 +2,9 @@
     "Check test_panelprep - no map - no chunks": {
         "content": [
             {
-                "workflow size": 36,
+                "workflow size": 32,
                 "versions": {
                     "BCFTOOLS_CONVERT": {
-                        "bcftools": "1.23.1"
-                    },
-                    "BCFTOOLS_INDEX": {
                         "bcftools": "1.23.1"
                     },
                     "BCFTOOLS_INDEX_LIGATE": {
@@ -45,9 +42,6 @@
                     },
                     "VCFCHREXTRACT": {
                         "bcftools": "1.22"
-                    },
-                    "VCFLIB_VCFFIXUP": {
-                        "vcflib": "1.0.14"
                     },
                     "Workflow": {
                         "nf-core/phaseimpute": "v1.2.0dev"
@@ -94,24 +88,20 @@
                     "prep_panel/panel/1000GP_chr21_16570070-16590513_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf",
                     "prep_panel/panel/1000GP_chr21_16590521-16609998_chunks.bcf.csi",
-                    "prep_panel/panel/1000GP_chr21_fixup.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_fixup.vcf.gz.tbi",
                     "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz.tbi",
-                    "prep_panel/panel/1000GP_chr21_normalized.vcf.gz",
-                    "prep_panel/panel/1000GP_chr21_normalized.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr21_multiallelic.vcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr21_normalized.bcf.gz",
+                    "prep_panel/panel/1000GP_chr21_normalized.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz",
                     "prep_panel/panel/1000GP_chr21_phased.vcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_16570065-16592216_chunks.bcf",
                     "prep_panel/panel/1000GP_chr22_16570065-16592216_chunks.bcf.csi",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf",
                     "prep_panel/panel/1000GP_chr22_16592229-16609999_chunks.bcf.csi",
-                    "prep_panel/panel/1000GP_chr22_fixup.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_fixup.vcf.gz.tbi",
                     "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz.tbi",
-                    "prep_panel/panel/1000GP_chr22_normalized.vcf.gz",
-                    "prep_panel/panel/1000GP_chr22_normalized.vcf.gz.tbi",
+                    "prep_panel/panel/1000GP_chr22_multiallelic.vcf.gz.csi",
+                    "prep_panel/panel/1000GP_chr22_normalized.bcf.gz",
+                    "prep_panel/panel/1000GP_chr22_normalized.bcf.gz.csi",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz",
                     "prep_panel/panel/1000GP_chr22_phased.vcf.gz.csi",
                     "prep_panel/posfile",
@@ -133,12 +123,12 @@
                     "1000GP_chr22_chunks_glimpse1.txt:md5,3344e171251722cf58ae31136da223ac",
                     "1000GP_chr21_chunks_glimpse2.txt:md5,834dea86a63b5a49d36f53c0ac7e01a2",
                     "1000GP_chr22_chunks_glimpse2.txt:md5,c363e235162ca0f7d22e5604c192e256",
-                    "1000GP_chr21.hap.gz:md5,64d7fdfc96ce79848cf9c3c220e6774f",
+                    "1000GP_chr21.hap.gz:md5,d18ac86ed7080c6527aade3b6717ebb0",
                     "1000GP_chr21.legend.gz:md5,3f7edc4c153521a0871c9d51f7da2372",
-                    "1000GP_chr21.samples:md5,d8ca3e8336976001de8df6be7ae236cb",
-                    "1000GP_chr22.hap.gz:md5,9500b831dcfee86a98577dde9e2cce73",
+                    "1000GP_chr21.samples:md5,ba53fdcb71cd6dbd218e0e932555086c",
+                    "1000GP_chr22.hap.gz:md5,40b908abc098ef9919f80b90a79f8c6c",
                     "1000GP_chr22.legend.gz:md5,82f6f97f61e68b4872cc14c0125ff037",
-                    "1000GP_chr22.samples:md5,d8ca3e8336976001de8df6be7ae236cb",
+                    "1000GP_chr22.samples:md5,ba53fdcb71cd6dbd218e0e932555086c",
                     "1000GP.chr21.posfile.txt.gz:md5,33d064c5132000799f3df9ea31967e12",
                     "1000GP.chr22.posfile.txt.gz:md5,f5997df5995dcdbc4ab31e1084b83541",
                     "1000GP.chr21.posfile.txt:md5,33d064c5132000799f3df9ea31967e12",
@@ -149,44 +139,28 @@
                 ],
                 "VCF files": [
                     [
-                        "1000GP_chr21_fixup.vcf.gz",
-                        "1a7f840b5311e45cad2210779cc90d7e"
-                    ],
-                    [
                         "1000GP_chr21_multiallelic.vcf.gz",
                         "1a7f840b5311e45cad2210779cc90d7e"
                     ],
                     [
-                        "1000GP_chr21_normalized.vcf.gz",
-                        "1a7f840b5311e45cad2210779cc90d7e"
-                    ],
-                    [
                         "1000GP_chr21_phased.vcf.gz",
-                        "797b0fd345ce761987d4b3bddac4236a"
-                    ],
-                    [
-                        "1000GP_chr22_fixup.vcf.gz",
-                        "e028aaa747cdb57516927d6dbd849ead"
+                        "52bcbe4476db8398ac7c5cf3ce089a50"
                     ],
                     [
                         "1000GP_chr22_multiallelic.vcf.gz",
                         "e028aaa747cdb57516927d6dbd849ead"
                     ],
                     [
-                        "1000GP_chr22_normalized.vcf.gz",
-                        "e028aaa747cdb57516927d6dbd849ead"
-                    ],
-                    [
                         "1000GP_chr22_phased.vcf.gz",
-                        "b489f8697dda10f5e2eafaa7053bd494"
+                        "7c06a12b5eb665b2b7b163acf8828710"
                     ],
                     [
                         "1000GP_chr21_glimpse1_sites.vcf.gz",
-                        "6a6015e06338ef14f58749dd067f4a78"
+                        "10fe85184e0afaddc094cf8450551cca"
                     ],
                     [
                         "1000GP_chr22_glimpse1_sites.vcf.gz",
-                        "321a19489c56a5d670ee49b26d9052b9"
+                        "c8dade5436fccb3839877a0749f1a665"
                     ]
                 ],
                 "CSV files": [
@@ -217,10 +191,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-17T14:17:12.552259413",
+        "timestamp": "2026-06-10T22:31:05.187191359",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.1"
         }
     },
     "Check test_panelprep - with map - with chunks": {

--- a/workflows/phaseimpute/tests/test_panelprep.nf.test.snap
+++ b/workflows/phaseimpute/tests/test_panelprep.nf.test.snap
@@ -160,7 +160,7 @@
                     ],
                     [
                         "1000GP_chr22_phased.vcf.gz",
-                        "7c06a12b5eb665b2b7b163acf8828710"
+                        "40ff314e91993a89f6ca95aa06f5ad86"
                     ],
                     [
                         "1000GP_chr21_glimpse1_sites.vcf.gz",
@@ -207,7 +207,7 @@
                 }
             }
         ],
-        "timestamp": "2026-06-11T15:53:36.17139211",
+        "timestamp": "2026-06-11T17:45:26.193201885",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"


### PR DESCRIPTION
<!--
# nf-core/phaseimpute pull request

Many thanks for contributing to nf-core/phaseimpute!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/phaseimpute/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

This PR fix the reproducibility issue with singularity on some machine.
After a lot of debugging this seemed to come from the `vcf.gz` format and `.tbi` index that when given to `SHAPEIT5_phase_common` would result in different phase for some individuals for just a few position but still throwing off the variants md5sum result.

To solve this without adding an extra module, `VCFLIB_VCFFIXUP` module was updated to output any vcf format + index.
This removed one module necessary and stabilised the hash.

See https://nfcore.slack.com/archives/C04PPJLT1T3/p1781099185452859 for the full rubber ducking.

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/phaseimpute/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/phaseimpute _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
